### PR TITLE
Edited line 91 to support multi OS support

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -88,7 +88,7 @@ function createComponent(path: string, className: string): void {
     }
 
     /** Folder Path */
-    const folder = `${path}\\${className}\\`
+    const folder = /^win/.test(process.platform) ? `${path}\\${className}\\` : `${path}/${className}/`;
 
     /** Options */
     const stylesheet = config.get<string>('stylesheet', 'none');


### PR DESCRIPTION
const folder = /^win/.test(process.platform) ? `${path}\\${className}\\` : `${path}/${className}/`

Tests if there is a windows platform, then uses this path, else uses the Linux path system. Im pretty sure this is the error.